### PR TITLE
Separate configuration for filter tests

### DIFF
--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderWebFilterFactoryTests.java
@@ -17,9 +17,6 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.time.Duration;
-import java.util.Map;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
@@ -28,19 +25,28 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.gateway.test.TestUtils.getMap;
 import static org.springframework.web.reactive.function.BodyExtractors.toMono;
 
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles(profiles = "request-header-web-filter")
 public class AddRequestHeaderWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterWebFilterFactoryTests.java
@@ -17,8 +17,6 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.util.Map;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
@@ -27,19 +25,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.gateway.test.TestUtils.getMap;
 import static org.springframework.web.reactive.function.BodyExtractors.toMono;
 
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles(profiles = "request-parameter-web-filter")
 public class AddRequestParameterWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/resources/application-request-header-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-request-header-web-filter.yml
@@ -1,0 +1,14 @@
+test:
+  hostport: httpbin.org:80
+  uri: lb://testservice
+
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_header_test
+        uri: ${test.uri}
+        predicates:
+        - Path=/headers
+        filters:
+        - AddRequestHeader=X-Request-Foo, Bar

--- a/spring-cloud-gateway-core/src/test/resources/application-request-parameter-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-request-parameter-web-filter.yml
@@ -1,0 +1,15 @@
+test:
+  hostport: httpbin.org:80
+  uri: lb://testservice
+
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_parameter_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.addrequestparameter.org
+        - Path=/get
+        filters:
+        - AddRequestParameter=foo, bar


### PR DESCRIPTION
Just a POC @spencergibb, wanted to see how the filter tests can be made to use a more specific configuration for the filter being tested. An approach I saw uses Spring Profiles to load up the specific `application-<profile>` configuration file. If you are good about this I can modify all the filter tests along the same lines - No need to merge this PR in, can be used purely for discussion.